### PR TITLE
Remove install guide related refs; add vim to dev

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitnami/python:3.13
 
-RUN apt update && apt upgrade -y
+RUN apt update && apt upgrade -y && apt install vim -y
 
 # Add dev requirements
 ADD requirements.txt /tmp/

--- a/.github/workflows/build-sphinx-docs.yml
+++ b/.github/workflows/build-sphinx-docs.yml
@@ -75,7 +75,7 @@ jobs:
 
           echo "
           Creating checksums.txt..."
-          sha512sum salt-user-guide.tar.gz salt.repo salt.sources | tee checksums.txt
+          sha512sum salt-user-guide.tar.gz | tee checksums.txt
 
       - name: Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda


### PR DESCRIPTION
- Add `vim` to container to ensure git edit capabilities with vim as editor of choice
- Remove install guide refs of `salt.repo` and `salt.sources` for sha generation