### PR TITLE
Exclude some initial files from sitemap

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,8 +127,14 @@ html_show_sourcelink = True  # False on private repos; True on public repos
 html_theme = 'furo'
 html_title = project
 html_baseurl = 'https://docs.saltproject.io/salt/user-guide/'
+
 # Extends baseurl, in combination with version value
 sitemap_locales = ['en']
+# Pages we don't care to include in generated sitemap file
+sitemap_excludes = [
+    "search.html",
+    "genindex.html",
+]
 
 html_theme_options = {
     "dark_css_variables": {


### PR DESCRIPTION
- Exclude `search.html` and `genindex.html` files from sitemap, as they wouldn't be useful for a crawler
- Follow-up finalized fix for #1